### PR TITLE
Disallow multiple soft deletion on the same entity

### DIFF
--- a/src/uow/AuditableRepository.ts
+++ b/src/uow/AuditableRepository.ts
@@ -78,11 +78,11 @@ export class AuditableRepository<T extends IAuditable> extends BaseRepository<T>
 
 
   async deleteMany(filter: Filter<T>): Promise<number> {
+    if (!this._configs.softDelete) return super.deleteMany(filter);
     const newFilter = this.getDeletedFilter(filter);
-    if (!this._configs.softDelete) return super.deleteMany(newFilter);
     const $set = <UpdateFilter<T>['$set']>{ deleted: this.getAuditObject() };
     const result = await this._collection.updateMany(
-      filter,
+      newFilter,
       { $set },
       { session: this._session }
     );
@@ -90,11 +90,11 @@ export class AuditableRepository<T extends IAuditable> extends BaseRepository<T>
   }
 
   async deleteOne(filter: Filter<T>): Promise<T | undefined> {
+    if (!this._configs.softDelete) return super.deleteOne(filter);
     const newFilter = this.getDeletedFilter(filter);
-    if (!this._configs.softDelete) return super.deleteOne(newFilter);
     const $set = <UpdateFilter<T>['$set']>{ deleted: this.getAuditObject() };
     const result = await this._collection.findOneAndUpdate(
-      filter,
+      newFilter,
       { $set },
       { returnDocument: 'after', session: this._session }
     );

--- a/src/uow/AuditableRepository.ts
+++ b/src/uow/AuditableRepository.ts
@@ -78,7 +78,8 @@ export class AuditableRepository<T extends IAuditable> extends BaseRepository<T>
 
 
   async deleteMany(filter: Filter<T>): Promise<number> {
-    if (!this._configs.softDelete) return super.deleteMany(filter);
+    const newFilter = this.getDeletedFilter(filter);
+    if (!this._configs.softDelete) return super.deleteMany(newFilter);
     const $set = <UpdateFilter<T>['$set']>{ deleted: this.getAuditObject() };
     const result = await this._collection.updateMany(
       filter,
@@ -89,7 +90,8 @@ export class AuditableRepository<T extends IAuditable> extends BaseRepository<T>
   }
 
   async deleteOne(filter: Filter<T>): Promise<T | undefined> {
-    if (!this._configs.softDelete) return super.deleteOne(filter);
+    const newFilter = this.getDeletedFilter(filter);
+    if (!this._configs.softDelete) return super.deleteOne(newFilter);
     const $set = <UpdateFilter<T>['$set']>{ deleted: this.getAuditObject() };
     const result = await this._collection.findOneAndUpdate(
       filter,


### PR DESCRIPTION
This PR ensures that an entity can't be softly deleted more than once. This is important in some cases when the developer plans to do some action on successful deletions.

For example:
```
const deleted=await this.storageRepo.deleteOne({_id:storageId});
if(deleted) await this.removeStorageFromStore(storeId, deleted);

```