### PR TITLE
find many pages- sort must precede skip limit

### DIFF
--- a/src/uow/BaseRepository.ts
+++ b/src/uow/BaseRepository.ts
@@ -114,12 +114,13 @@ export class BaseRepository<T extends IEntity> implements IRepository<T> {
     logger.trace('findMany', this._name, JSON.stringify(filter), JSON.stringify(paging), JSON.stringify(projection));
     const total = await this._collection.countDocuments(filter, <{}>{ fields: projection, session: this._session });
     let cursor = this._collection
-      .find<T>(filter, { projection, session: this._session })
-      .skip(paging.index * paging.size)
-      .limit(paging.size);
+      .find<T>(filter, { projection, session: this._session });
     if (paging.sorter) {
       cursor = cursor.sort(paging.sorter);
     }
+    cursor = cursor.skip(paging.index * paging.size)
+      .limit(paging.size);
+
     const items = await cursor.toArray();
     return <IPage<T>>{
       index: paging.index + 1,


### PR DESCRIPTION
In the findManPage method, it is important to place the sort operation before the skip and limit operations. This ordering is necessary because the sort operation impacts the order in which the documents are returned, and the subsequent skip and limit operations are applied to the sorted result set. Therefore, the sorting operation needs to be executed first to ensure that the skip and limit operations are performed on the correctly ordered documents.